### PR TITLE
Fix POTM upgrade showing previous perks too

### DIFF
--- a/src/constants/hotm.js
+++ b/src/constants/hotm.js
@@ -768,7 +768,9 @@ class PeakOfTheMountain extends Node {
   perk(level) {
     const output = [];
 
-    for (let tier = 1; tier <= level; tier++) {
+    const baseTier = level > this.level ? level : 1;
+
+    for (let tier = baseTier; tier <= level; tier++) {
       for (const [reward, qty] of Object.entries(rewards.potm[tier])) {
         const qtyColor = rewards.rewards[reward].qtyColor;
         const formatted = rewards.rewards[reward].formatted;


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/2744227/194945788-6564dd21-c8c4-467f-9cf1-92e9680ef2cb.png)

# After
![image](https://user-images.githubusercontent.com/2744227/194945770-50199e07-c173-4e94-9063-7233d6a9589e.png)
